### PR TITLE
Fix #48 --append functionality (#174)

### DIFF
--- a/makeself-header.sh
+++ b/makeself-header.sh
@@ -341,7 +341,6 @@ do
 	echo CRCsum=\"\$CRCsum\"
 	echo MD5sum=\"\$MD5sum\"
 	echo SHAsum=\"\$SHAsum\"
-	echo OLDUSIZE=$USIZE
 	echo OLDSKIP=`expr $SKIP + 1`
 	exit 0
 	;;

--- a/makeself.sh
+++ b/makeself.sh
@@ -591,6 +591,9 @@ fi
 
 tmparch="${TMPDIR:-/tmp}/mkself$$.tar"
 (
+    if test "$APPEND" = "y"; then
+        tail -n +$OLDSKIP "$archname" | $GUNZIP_CMD > "$tmparch"
+    fi
     cd "$archdir"
     find . ! -type d \
         | LC_ALL=C sort \
@@ -601,6 +604,8 @@ tmparch="${TMPDIR:-/tmp}/mkself$$.tar"
     rm -f "$tmparch" "$tmpfile"
     exit 1
 }
+
+USIZE=`du $DU_ARGS "$tmparch" | awk '{print $1}'`
 
 eval "$GZIP_CMD" <"$tmparch" >"$tmpfile" || {
     echo "ERROR: failed to create temporary file: $tmpfile"
@@ -682,15 +687,12 @@ if test "$APPEND" = y; then
     mv "$archname" "$archname".bak || exit
 
     # Prepare entry for new archive
-    filesizes="$filesizes $fsize"
-    CRCsum="$CRCsum $crcsum"
-    MD5sum="$MD5sum $md5sum"
-    SHAsum="$SHAsum $shasum"
-    USIZE=`expr $USIZE + $OLDUSIZE`
+    filesizes="$fsize"
+    CRCsum="$crcsum"
+    MD5sum="$md5sum"
+    SHAsum="$shasum"
     # Generate the header
     . "$HEADER"
-    # Append the original data
-    tail -n +$OLDSKIP "$archname".bak >> "$archname"
     # Append the new data
     cat "$tmpfile" >> "$archname"
 

--- a/test/appendtest
+++ b/test/appendtest
@@ -11,18 +11,38 @@ setupTests() {
   $SUT $* archive makeself-test.run "Test $*" echo Testing --tar-extra="--exclude .git" 
   mkdir -p append/append_dir/
   cp -a $SOURCE/makeself.sh append/append_dir/
-  $SUT --append append/ makeself-test.run
-
 }
 
 
 testGzip()
 {
   setupTests --gzip
-  
+
+  $SUT --append append/ makeself-test.run
+  assertEqual $? 0
   ./makeself-test.run --check
   assertEqual $? 0
 }
 
+
+testNocomp()
+{
+  setupTests --nocomp
+
+  $SUT --append append/ makeself-test.run
+  assertEqual $? 0
+  ./makeself-test.run --check
+  assertEqual $? 0
+}
+
+testBzip2()
+{
+  setupTests --bzip2
+
+  $SUT --append append/ makeself-test.run
+  assertEqual $? 0
+  ./makeself-test.run --check
+  assertEqual $? 0
+}
 
 source bashunit/bashunit.bash


### PR DESCRIPTION
* Fix #48 --append functionality

* Fix #48 --append functionality

Also adds some additional testing to the appendtest to catch
previously uncaught failure modes.

* Use size of uncompressed tar for USIZE

Change covers the corner case where files are updated in the archive
during an --append. Removes the necessity for the OLDUSIZE variable.